### PR TITLE
Changes to make the examples run on Fresh Install

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,11 +3,11 @@
         "name": "Mac M1 LLVM OpenMP",
         "includePath": [
             "${workspaceFolder}/**",
-            "/opt/homebrew/opt/libomp/lib"
+            "/usr/local/opt/libomp/lib"
         ],
         "defines": [],
         "macFrameworkPath": [],
-        "compilerPath": "/opt/homebrew/opt/llvm/bin/clang++",
+        "compilerPath": "/usr/local/opt/llvm/bin/clang++",
         "cStandard": "c17",
         "cppStandard": "c++20",
         "intelliSenseMode": "clang-x64",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+    "doublebuffer.metal-shader"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,14 +1,5 @@
 {
-    "configurations": [{
-            "name": "Python: Current File",
-            "type": "python",
-            "request": "launch",
-            "program": "${file}",
-            "console": "integratedTerminal",
-            "justMyCode": true,
-            "cwd": "${workspaceFolder}/paper",
-
-        },
+    "configurations": [
         {
             "name": "MetalAdder benchmark debugging",
             "type": "cppdbg",
@@ -33,6 +24,42 @@
             "externalConsole": false,
             "MIMode": "lldb",
             "preLaunchTask": "Build 02"
+        }, {
+            "name": "MetalOperations Chaining debugging",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/02-GeneralArrayOperations/chaining_benchmark.x",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/02-GeneralArrayOperations",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "lldb",
+            "preLaunchTask": "Build 02 chaining"
+        },  {
+            "name": "MetalOperations benchmark paper debugging",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/paper/paper_benchmark_02.x",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/02-GeneralArrayOperations",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "lldb",
+            "preLaunchTask": "Build benchmark paper 02"
+        }, {
+            "name": "2DKernels debugging",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/03-2DKernels/benchmark.x",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/03-2DKernels",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "lldb",
+            "preLaunchTask": "Build 03"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,9 +8,7 @@
 				"-std=c++17",
 				"-stdlib=libc++",
 				"-O2",
-				// OpenMP includes & configuration
 				"-L/usr/local/opt/libomp/lib", "-fopenmp",
-				// Metal includes & configuration
 				"-I${workspaceFolder}/metal-cpp", "-fno-objc-arc",
 				"-framework", "Metal", "-framework", "Foundation", "-framework", "MetalKit",
 				"-g",
@@ -29,9 +27,8 @@
 				"isDefault": true
 			},
 			"detail": "compiler: /usr/local/opt/llvm/bin/clang++",
-			"dependsOn": ["Build .metallib 01"],
+			"dependsOn": ["Build .metallib 01"]
 		},
-		// See: https://developer.apple.com/documentation/metal/shader_libraries/building_a_library_with_metal_s_command-line_tools?language=objc
 		{
 			"type": "shell",
 			"label": "Build .air 01",
@@ -59,9 +56,7 @@
 				"-std=c++17",
 				"-stdlib=libc++",
 				"-O2",
-				// OpenMP includes & configuration
 				"-L/usr/local/opt/libomp/lib", "-fopenmp",
-				// Metal includes & configuration
 				"-I${workspaceFolder}/metal-cpp", "-fno-objc-arc",
 				"-framework", "Metal", "-framework", "Foundation", "-framework", "MetalKit",
 				"-g",
@@ -82,7 +77,7 @@
 				"isDefault": true
 			},
 			"detail": "compiler: /usr/local/opt/llvm/bin/clang++",
-			"dependsOn": ["Build .metallib 02"],
+			"dependsOn": ["Build .metallib 02"]
 		}, {
 			"type": "cppbuild",
 			"label": "Build 02",
@@ -91,9 +86,7 @@
 				"-std=c++17",
 				"-stdlib=libc++",
 				"-O2",
-				// OpenMP includes & configuration
 				"-L/usr/local/opt/libomp/lib", "-fopenmp",
-				// Metal includes & configuration
 				"-I${workspaceFolder}/metal-cpp", "-fno-objc-arc",
 				"-framework", "Metal", "-framework", "Foundation", "-framework", "MetalKit",
 				"-g",
@@ -114,7 +107,7 @@
 				"isDefault": true
 			},
 			"detail": "compiler: /usr/local/opt/llvm/bin/clang++",
-			"dependsOn": ["Build .metallib 02"],
+			"dependsOn": ["Build .metallib 02"]
 		}, {
 			"type": "cppbuild",
 			"label": "Build benchmark paper 02",
@@ -123,9 +116,7 @@
 				"-std=c++17",
 				"-stdlib=libc++",
 				"-O2",
-				// OpenMP includes & configuration
 				"-L/usr/local/opt/libomp/lib", "-fopenmp",
-				// Metal includes & configuration
 				"-I${workspaceFolder}/metal-cpp", "-fno-objc-arc",
 				"-framework", "Metal", "-framework", "Foundation", "-framework", "MetalKit",
 				"-g",
@@ -146,7 +137,7 @@
 				"isDefault": true
 			},
 			"detail": "compiler: /usr/local/opt/llvm/bin/clang++",
-			"dependsOn": ["Build .metallib 02"],
+			"dependsOn": ["Build .metallib 02"]
 		}, {
 			"type": "shell",
 			"label": "Build .air 02",
@@ -174,9 +165,7 @@
 				"-std=c++17",
 				"-stdlib=libc++",
 				"-O2",
-				// OpenMP includes & configuration
 				"-L/usr/local/opt/libomp/lib", "-fopenmp",
-				// Metal includes & configuration
 				"-I${workspaceFolder}/metal-cpp", "-fno-objc-arc",
 				"-framework", "Metal", "-framework", "Foundation", "-framework", "MetalKit",
 				"-g",
@@ -197,19 +186,16 @@
 				"isDefault": true
 			},
 			"detail": "compiler: /usr/local/opt/llvm/bin/clang++",
-			"dependsOn": ["Build .metallib 03"],
+			"dependsOn": ["Build .metallib 03"]
 		}, {
 			"type": "cppbuild",
 			"label": "Build benchmark paper 03",
 			"command": "/usr/local/opt/llvm/bin/clang++",
 			"args": [
 				"-std=c++17",
-				// "-stdlib=libc++",
 				"-std=c++11",
 				"-O2",
-				// OpenMP includes & configuration
 				"-L/usr/local/opt/libomp/lib", "-fopenmp",
-				// Metal includes & configuration
 				"-I${workspaceFolder}/metal-cpp", "-fno-objc-arc",
 				"-framework", "Metal", "-framework", "Foundation", "-framework", "MetalKit",
 				"-g",
@@ -230,7 +216,7 @@
 				"isDefault": true
 			},
 			"detail": "compiler: /usr/local/opt/llvm/bin/clang++",
-			"dependsOn": ["Build .metallib 03"],
+			"dependsOn": ["Build .metallib 03"]
 		}, {
 			"type": "shell",
 			"label": "Build .air 03",
@@ -250,6 +236,6 @@
 			],
 			"dependsOn": ["Build .air 03"]
 
-		},
+		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,13 +3,13 @@
 	"tasks": [{
 			"type": "cppbuild",
 			"label": "Build 01",
-			"command": "/opt/homebrew/opt/llvm/bin/clang++",
+			"command": "/usr/local/opt/llvm/bin/clang++",
 			"args": [
 				"-std=c++17",
 				"-stdlib=libc++",
 				"-O2",
 				// OpenMP includes & configuration
-				"-L/opt/homebrew/opt/libomp/lib", "-fopenmp",
+				"-L/usr/local/opt/libomp/lib", "-fopenmp",
 				// Metal includes & configuration
 				"-I${workspaceFolder}/metal-cpp", "-fno-objc-arc",
 				"-framework", "Metal", "-framework", "Foundation", "-framework", "MetalKit",
@@ -28,7 +28,7 @@
 				"kind": "build",
 				"isDefault": true
 			},
-			"detail": "compiler: /opt/homebrew/opt/llvm/bin/clang++",
+			"detail": "compiler: /usr/local/opt/llvm/bin/clang++",
 			"dependsOn": ["Build .metallib 01"],
 		},
 		// See: https://developer.apple.com/documentation/metal/shader_libraries/building_a_library_with_metal_s_command-line_tools?language=objc
@@ -54,13 +54,13 @@
 		}, {
 			"type": "cppbuild",
 			"label": "Build 02 chaining",
-			"command": "/opt/homebrew/opt/llvm/bin/clang++",
+			"command": "/usr/local/opt/llvm/bin/clang++",
 			"args": [
 				"-std=c++17",
 				"-stdlib=libc++",
 				"-O2",
 				// OpenMP includes & configuration
-				"-L/opt/homebrew/opt/libomp/lib", "-fopenmp",
+				"-L/usr/local/opt/libomp/lib", "-fopenmp",
 				// Metal includes & configuration
 				"-I${workspaceFolder}/metal-cpp", "-fno-objc-arc",
 				"-framework", "Metal", "-framework", "Foundation", "-framework", "MetalKit",
@@ -81,18 +81,18 @@
 				"kind": "build",
 				"isDefault": true
 			},
-			"detail": "compiler: /opt/homebrew/opt/llvm/bin/clang++",
+			"detail": "compiler: /usr/local/opt/llvm/bin/clang++",
 			"dependsOn": ["Build .metallib 02"],
 		}, {
 			"type": "cppbuild",
 			"label": "Build 02",
-			"command": "/opt/homebrew/opt/llvm/bin/clang++",
+			"command": "/usr/local/opt/llvm/bin/clang++",
 			"args": [
 				"-std=c++17",
 				"-stdlib=libc++",
 				"-O2",
 				// OpenMP includes & configuration
-				"-L/opt/homebrew/opt/libomp/lib", "-fopenmp",
+				"-L/usr/local/opt/libomp/lib", "-fopenmp",
 				// Metal includes & configuration
 				"-I${workspaceFolder}/metal-cpp", "-fno-objc-arc",
 				"-framework", "Metal", "-framework", "Foundation", "-framework", "MetalKit",
@@ -113,18 +113,18 @@
 				"kind": "build",
 				"isDefault": true
 			},
-			"detail": "compiler: /opt/homebrew/opt/llvm/bin/clang++",
+			"detail": "compiler: /usr/local/opt/llvm/bin/clang++",
 			"dependsOn": ["Build .metallib 02"],
 		}, {
 			"type": "cppbuild",
 			"label": "Build benchmark paper 02",
-			"command": "/opt/homebrew/opt/llvm/bin/clang++",
+			"command": "/usr/local/opt/llvm/bin/clang++",
 			"args": [
 				"-std=c++17",
 				"-stdlib=libc++",
 				"-O2",
 				// OpenMP includes & configuration
-				"-L/opt/homebrew/opt/libomp/lib", "-fopenmp",
+				"-L/usr/local/opt/libomp/lib", "-fopenmp",
 				// Metal includes & configuration
 				"-I${workspaceFolder}/metal-cpp", "-fno-objc-arc",
 				"-framework", "Metal", "-framework", "Foundation", "-framework", "MetalKit",
@@ -145,7 +145,7 @@
 				"kind": "build",
 				"isDefault": true
 			},
-			"detail": "compiler: /opt/homebrew/opt/llvm/bin/clang++",
+			"detail": "compiler: /usr/local/opt/llvm/bin/clang++",
 			"dependsOn": ["Build .metallib 02"],
 		}, {
 			"type": "shell",
@@ -169,13 +169,13 @@
 		}, {
 			"type": "cppbuild",
 			"label": "Build 03",
-			"command": "/opt/homebrew/opt/llvm/bin/clang++",
+			"command": "/usr/local/opt/llvm/bin/clang++",
 			"args": [
 				"-std=c++17",
 				"-stdlib=libc++",
 				"-O2",
 				// OpenMP includes & configuration
-				"-L/opt/homebrew/opt/libomp/lib", "-fopenmp",
+				"-L/usr/local/opt/libomp/lib", "-fopenmp",
 				// Metal includes & configuration
 				"-I${workspaceFolder}/metal-cpp", "-fno-objc-arc",
 				"-framework", "Metal", "-framework", "Foundation", "-framework", "MetalKit",
@@ -196,19 +196,19 @@
 				"kind": "build",
 				"isDefault": true
 			},
-			"detail": "compiler: /opt/homebrew/opt/llvm/bin/clang++",
+			"detail": "compiler: /usr/local/opt/llvm/bin/clang++",
 			"dependsOn": ["Build .metallib 03"],
 		}, {
 			"type": "cppbuild",
 			"label": "Build benchmark paper 03",
-			"command": "/opt/homebrew/opt/llvm/bin/clang++",
+			"command": "/usr/local/opt/llvm/bin/clang++",
 			"args": [
 				"-std=c++17",
 				// "-stdlib=libc++",
 				"-std=c++11",
 				"-O2",
 				// OpenMP includes & configuration
-				"-L/opt/homebrew/opt/libomp/lib", "-fopenmp",
+				"-L/usr/local/opt/libomp/lib", "-fopenmp",
 				// Metal includes & configuration
 				"-I${workspaceFolder}/metal-cpp", "-fno-objc-arc",
 				"-framework", "Metal", "-framework", "Foundation", "-framework", "MetalKit",
@@ -229,7 +229,7 @@
 				"kind": "build",
 				"isDefault": true
 			},
-			"detail": "compiler: /opt/homebrew/opt/llvm/bin/clang++",
+			"detail": "compiler: /usr/local/opt/llvm/bin/clang++",
 			"dependsOn": ["Build .metallib 03"],
 		}, {
 			"type": "shell",

--- a/02-GeneralArrayOperations/ops.metal
+++ b/02-GeneralArrayOperations/ops.metal
@@ -63,8 +63,7 @@ kernel void inspector(
                   uint quadgroup_index_in_threadgroup          [[quadgroup_index_in_threadgroup]], 
                   uint quadgroups_per_threadgroup              [[quadgroups_per_threadgroup]], 
                   uint simdgroup_index_in_threadgroup          [[simdgroup_index_in_threadgroup]], 
-                  uint simdgroups_per_threadgroup              [[simdgroups_per_threadgroup]], 
-                  uint thread_execution_width                  [[thread_execution_width]], 
+                  uint simdgroups_per_threadgroup              [[simdgroups_per_threadgroup]],
                   uint thread_index_in_quadgroup               [[thread_index_in_quadgroup]], 
                   uint thread_index_in_simdgroup               [[thread_index_in_simdgroup]], 
                   uint thread_index_in_threadgroup             [[thread_index_in_threadgroup]], 
@@ -88,15 +87,14 @@ kernel void inspector(
         store[8] = quadgroups_per_threadgroup;      
         store[9] = simdgroup_index_in_threadgroup;
         store[10] = simdgroups_per_threadgroup;
-        store[11] = thread_execution_width;
-        store[12] = thread_index_in_quadgroup;
-        store[13] = thread_index_in_simdgroup;
-        store[14] = thread_index_in_threadgroup;
-        store[15] = thread_position_in_threadgroup;
-        store[16] = threadgroup_position_in_grid;
-        store[17] = threadgroups_per_grid;
-        store[18] = threads_per_simdgroup;
-        store[19] = threads_per_threadgroup;
+        store[11] = thread_index_in_quadgroup;
+        store[12] = thread_index_in_simdgroup;
+        store[13] = thread_index_in_threadgroup;
+        store[14] = thread_position_in_threadgroup;
+        store[15] = threadgroup_position_in_grid;
+        store[16] = threadgroups_per_grid;
+        store[17] = threads_per_simdgroup;
+        store[18] = threads_per_threadgroup;
     }
 
 }

--- a/03-2DKernels/ops.metal
+++ b/03-2DKernels/ops.metal
@@ -133,7 +133,6 @@ kernel void inspector(
                   uint quadgroups_per_threadgroup              [[quadgroups_per_threadgroup]], 
                   uint simdgroup_index_in_threadgroup          [[simdgroup_index_in_threadgroup]], 
                   uint simdgroups_per_threadgroup              [[simdgroups_per_threadgroup]], 
-                  uint thread_execution_width                  [[thread_execution_width]], 
                   uint thread_index_in_quadgroup               [[thread_index_in_quadgroup]], 
                   uint thread_index_in_simdgroup               [[thread_index_in_simdgroup]], 
                   uint thread_index_in_threadgroup             [[thread_index_in_threadgroup]], 
@@ -157,15 +156,14 @@ kernel void inspector(
         store[8] = quadgroups_per_threadgroup;      
         store[9] = simdgroup_index_in_threadgroup;
         store[10] = simdgroups_per_threadgroup;
-        store[11] = thread_execution_width;
-        store[12] = thread_index_in_quadgroup;
-        store[13] = thread_index_in_simdgroup;
-        store[14] = thread_index_in_threadgroup;
-        store[15] = thread_position_in_threadgroup;
-        store[16] = threadgroup_position_in_grid;
-        store[17] = threadgroups_per_grid;
-        store[18] = threads_per_simdgroup;
-        store[19] = threads_per_threadgroup;
+        store[11] = thread_index_in_quadgroup;
+        store[12] = thread_index_in_simdgroup;
+        store[13] = thread_index_in_threadgroup;
+        store[14] = thread_position_in_threadgroup;
+        store[15] = threadgroup_position_in_grid;
+        store[16] = threadgroups_per_grid;
+        store[17] = threads_per_simdgroup;
+        store[18] = threads_per_threadgroup;
     }
 
 }


### PR DESCRIPTION
I found a couple of things I had to change to get the repo to run on my fresh install on my machine (also an intel machine, not an M series).

* `thread_execution_width` is now deprecated and causes compiler errors. All references to it have been removed, and the `store` array has been reindexed.
* AFAIK standard `brew` install paths have changed from `/opt/homebrew/opt/` to `/usr/local/opt/`

Improvements/non-required changes I made
* I added Launch Targets that point at all of the top level tasks
* I edited the `tasks.json` file to be json compliant so I could `jq` it while trying to work out a bug that was actually just  invoking a target that relied on relative paths from the wrong directory.

Let me know if my changes sound reasonable, or if you would like to only let through some/a modification to them. Also, I would recommend adding a note about the launch targets displaying program output to the Debug Console (at least on my config) because that was very non-obvious to me.